### PR TITLE
Grafana weak credential

### DIFF
--- a/weak_credentials/grafana/Dockerfile.Grafana
+++ b/weak_credentials/grafana/Dockerfile.Grafana
@@ -1,0 +1,12 @@
+FROM grafana/grafana:10.0.0
+
+ENV GF_INSTALL_PLUGINS=grafana-simple-json-datasource
+
+# override some default values
+ENV GF_SECURITY_ADMIN_USER=admin
+ENV GF_SECURITY_ADMIN_PASSWORD=qwertyuiop
+ENV GF_SECURITY_DISABLE_BRUTE_FORCE_LOGIN_PROTECTION=TRUE
+
+HEALTHCHECK CMD curl --fail http://localhost:3000/ || exit
+
+EXPOSE 3000

--- a/weak_credentials/grafana/grafana.md
+++ b/weak_credentials/grafana/grafana.md
@@ -1,9 +1,9 @@
 # Grafana
 
 # Note
-The `Dockerfile.Grafana` contains the following customisation:
+The `Dockerfile.Grafana` contains the following customization:
 - the admin user is created with the credential `admin:qwertyuiop` instead of the usual `admin:admin`
-- grafana is started with disabled brute force login protection (`GF_SECURITY_DISABLE_BRUTE_FORCE_LOGIN_PROTECTION=TRUE`) - by default it is enable
+- grafana is started with disabled brute force login protection (`GF_SECURITY_DISABLE_BRUTE_FORCE_LOGIN_PROTECTION=TRUE`) - by default it is enabled
 
 # Setup
 1. Ensure the files `runAndBuildGraphana.sh` and `Dockerfile.Grafana` are in the same folder
@@ -12,4 +12,4 @@ The `Dockerfile.Grafana` contains the following customisation:
 
 3. Connect to http://localhost:8873/ via browser
 
-4. Verify that grafana is running correctly by logging in with credential `admin:qwertyuiop`
+4. Verify that grafana is running correctly by logging in with credentials `admin:qwertyuiop`

--- a/weak_credentials/grafana/grafana.md
+++ b/weak_credentials/grafana/grafana.md
@@ -1,0 +1,15 @@
+# Grafana
+
+# Note
+The `Dockerfile.Grafana` contains the following customisation:
+- the admin user is created with the credential `admin:qwertyuiop` instead of the usual `admin:admin`
+- grafana is started with disabled brute force login protection (`GF_SECURITY_DISABLE_BRUTE_FORCE_LOGIN_PROTECTION=TRUE`) - by default it is enable
+
+# Setup
+1. Ensure the files `runAndBuildGraphana.sh` and `Dockerfile.Grafana` are in the same folder
+
+2. Create docker images with this command: `chmod +x runAndBuildGraphana.sh && ./runAndBuildGraphana.sh`
+
+3. Connect to http://localhost:8873/ via browser
+
+4. Verify that grafana is running correctly by logging in with credential `admin:qwertyuiop`

--- a/weak_credentials/grafana/runAndBuildGraphana.sh
+++ b/weak_credentials/grafana/runAndBuildGraphana.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+docker build --platform linux --no-cache -t graphana:test -f Dockerfile.Grafana . && docker run -p 127.0.0.1:8873:3000 -it --rm graphana:test


### PR DESCRIPTION
Testbed for grafana with the following custom settings:

- custom admin credential (`admin:qwertyuiop`)
- disabled login ratelimit