### PR TITLE
RCE and Arbitrary File Read PHP webapp in docker

### DIFF
--- a/php/rce_and_arbitrary_file_read_php/Dockerfile
+++ b/php/rce_and_arbitrary_file_read_php/Dockerfile
@@ -1,0 +1,19 @@
+FROM php
+
+USER root
+
+COPY startup.sh /
+RUN chmod 0744 /startup.sh
+
+COPY index.php /var/www/html/
+
+RUN apt-get update && \
+    apt-get install -y procps cron
+
+EXPOSE 80
+
+# Start crond and phpd
+ENTRYPOINT ["/startup.sh"]
+CMD ["php", "-S", "0.0.0.0:80", "-t", "/var/www/html", "/var/www/html/index.php"]
+
+

--- a/php/rce_and_arbitrary_file_read_php/README.md
+++ b/php/rce_and_arbitrary_file_read_php/README.md
@@ -1,0 +1,18 @@
+# A simple PHP webapp vulnerable to RCE and Arbitrary File Read
+
+ This webapp can be used for testing RCE and arbitrary file read exploitation. It was originally created to test 
+ blind RCE payload (linux_curl_trace_read).
+
+# Setup
+
+1. Build with:
+
+   `docker build --platform linux/amd64 -t rce-read .`
+   
+2. Run with:
+   
+   `docker run --rm  -p 8888:80 --name rce-read --platform linux/amd64 rce-read`
+
+3. Open the webapp at:
+
+   `http://localhost:8888/`

--- a/php/rce_and_arbitrary_file_read_php/index.php
+++ b/php/rce_and_arbitrary_file_read_php/index.php
@@ -1,0 +1,23 @@
+<html>
+<body>
+
+<?php  
+    echo "Hello, ";
+    echo "<br><br>\n\n";
+
+    if (isset($_GET['cmd']))  {
+        echo "Running [". $_GET['cmd'] . "] <br><br>\n";
+        system($_GET['cmd']);
+        
+    } elseif (isset($_GET['file_to_read']) )  {
+        echo "Reading ". $_GET['file_to_read'];
+        echo file_get_contents($_GET['file_to_read']);
+
+    } else {
+        echo "Error: This script requires 'cmd' or 'file_to_read'  parameter.";
+    }
+
+?>  
+
+</body>
+</html>

--- a/php/rce_and_arbitrary_file_read_php/startup.sh
+++ b/php/rce_and_arbitrary_file_read_php/startup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cron
+exec "$@"


### PR DESCRIPTION
A simple PHP webapp vulnerable to RCE and Arbitrary File Read.
This webapp can be used for testing RCE and arbitrary file read exploitation. 

It was originally created to test  blind RCE payload (linux_curl_trace_read).