### PR TITLE
Add vulnerable docker files for CVE-2020-13927

### DIFF
--- a/apache/airflow/CVE-2020-13927/README.md
+++ b/apache/airflow/CVE-2020-13927/README.md
@@ -1,0 +1,12 @@
+# Apache Airflow CVE-2020-13927
+
+This directory contains the deployment config for Apache Airflow. Version 1.10.10 and below is vulnerable to this CVE assigned vulnerability.
+
+The deployed service listens on port `8080`.
+
+## Vulnerable version
+docker-compose -f vuln-docker-compose.yml up -d
+
+## Fixed version
+docker-compose -f fixed-docker-compose.yml up -d
+

--- a/apache/airflow/CVE-2020-13927/fixed-docker-compose.yml
+++ b/apache/airflow/CVE-2020-13927/fixed-docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+x-airflow-common:
+  &airflow-common
+  image: apache/airflow:1.10.11
+  environment:
+    &airflow-common-env
+    AIRFLOW__WEBSERVER__AUTHENTICATE: 'true'
+    AIRFLOW__WEBSERVER__AUTH_BACKEND: 'airflow.contrib.auth.backends.password_auth'
+    AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
+  user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
+
+
+services:
+  airflow-webserver:
+    <<: *airflow-common
+    # Installing apache-airflow[password]==1.10.11 to add 
+    entrypoint: ["/bin/bash", "-c", "pip install 'apache-airflow[password]==1.10.11' --user && airflow initdb && (airflow webserver & airflow scheduler)"]
+    ports:
+      - 8080:8080
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: always
+

--- a/apache/airflow/CVE-2020-13927/vuln-docker-compose.yml
+++ b/apache/airflow/CVE-2020-13927/vuln-docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+x-airflow-common:
+  &airflow-common
+  image: apache/airflow:1.10.10
+  environment:
+    &airflow-common-env
+    AIRFLOW__WEBSERVER__AUTHENTICATE: 'true'
+    AIRFLOW__WEBSERVER__AUTH_BACKEND: 'airflow.contrib.auth.backends.password_auth'
+    AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
+  user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
+
+
+services:
+  airflow-webserver:
+    <<: *airflow-common
+    # Installing apache-airflow[password]==1.10.10 to add 
+    entrypoint: ["/bin/bash", "-c", "pip install 'apache-airflow[password]==1.10.10' --user && airflow initdb && (airflow webserver & airflow scheduler)"]
+    ports:
+      - 8080:8080
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: always
+


### PR DESCRIPTION
Hi,

These are the vulnerable and fixed docker files for CVE-2020-13927. Plugin issue for this vulnerability is [here](https://github.com/google/tsunami-security-scanner-plugins/issues/400)