### PR TITLE
Testbed for Exposed spark UI and API for Tsunami Plugin

### DIFF
--- a/apache/spark/exposed_api/README.md
+++ b/apache/spark/exposed_api/README.md
@@ -1,0 +1,13 @@
+# Apache Spark Exposed API
+
+This directory contains a docker-compose file which sets up an Apache Spark environment which exposes the Spark API to an unauthenticated attacker.
+
+In the worst case such an exposed endpoint allows an unauthenticated attacker to execute arbitrary code by dynamically loading an attacker-controlled JAR and execute arbitrary code.
+
+## Environment 
+
+The deployed environment contains a Spark `master` node which exposes its' API endpoint on the default port `6066`.
+
+The environment also contains a worker node which processes the attacker-submitted task.
+
+The environment can be started with `docker compose up -d`

--- a/apache/spark/exposed_api/docker-compose.yml
+++ b/apache/spark/exposed_api/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+
+services:
+  master:
+    image: docker.io/bitnami/spark:3.4.2
+    entrypoint: ["/bin/bash", "-c", "echo \"spark.master.rest.enabled true\" >> /opt/bitnami/spark/conf/spark-defaults.conf && /opt/bitnami/scripts/spark/entrypoint.sh /opt/bitnami/scripts/spark/run.sh"]
+    environment:
+      - SPARK_MODE=master
+    ports:
+      - '6066:6066'
+  slave:
+    entrypoint: ["/bin/bash", "-c", "/opt/bitnami/scripts/spark/entrypoint.sh /opt/bitnami/scripts/spark/run.sh"]
+    image: docker.io/bitnami/spark:3.4.2
+    depends_on:
+      - master
+    healthcheck:
+      # Our master takes a few seconds to be able to accept workers. 
+      # The start-worker.sh script exits with "0", even if it didn't connect successfully. However, it exits with 1 if the worker is already registered.
+      # The following command switches the exit codes around. As soon as a worker is already registered, the health check is successful.
+      test: bash -c 'if /opt/bitnami/spark/sbin/start-worker.sh spark://master:7077; then exit 1; else exit 0;fi' 
+      interval: 3s
+      retries: 5
+      start_period: 5s
+      timeout: 5s

--- a/apache/spark/exposed_ui/README.md
+++ b/apache/spark/exposed_ui/README.md
@@ -1,0 +1,11 @@
+# Apache Spark Exposed Web UI
+
+This directory contains a docker-compose file which sets up an Apache Spark environment which exposes it's web UI to an unauthenticated attacker.
+
+In the worst case such an exposed endpoint allows an unauthenticated attacker to retrieve data about tasks run by the server.
+
+## Environment 
+
+The deployed environment contains a Spark `master` node which exposes its web UI on the default port `8080`.
+
+The environment can be started with `docker compose up -d`

--- a/apache/spark/exposed_ui/docker-compose.yml
+++ b/apache/spark/exposed_ui/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  master:
+    image: docker.io/bitnami/spark:3.4.2
+    entrypoint: ["/bin/bash", "-c", "/opt/bitnami/scripts/spark/entrypoint.sh /opt/bitnami/scripts/spark/run.sh"]
+    environment:
+      - SPARK_MODE=master
+    ports:
+      - '8080:8080'


### PR DESCRIPTION
Testbed for Exposed Spark UI and API for the following tsunami AI plugin: 

https://github.com/google/tsunami-security-scanner-plugins/issues/416

As described in the previous issue, this issue is not considered a vulnerability by the Apache Spark team. Instead they see this as a configuration issue on the user side. 

This might allow us to use the `latest` tag for the Dockerfile, however most likely at some point in the future this would break things.
