### PR TITLE
Add CVE-2023-6977 Vulnerable Environment

### DIFF
--- a/mlflow/CVE-2023-6977/README.md
+++ b/mlflow/CVE-2023-6977/README.md
@@ -1,0 +1,11 @@
+# MLflow CVE-2023-6977
+
+This directory contains the deployment config for MLflow instances vulnerable and fixed to CVE-2023-6977. MLflow versions below 2.9.2 are vulnerable to that arbitrary file read vulnerability.
+
+The deployed service listens on port `5000` after the docker completes its job.
+
+## Vulnerable version
+docker run -p 127.0.0.1:5000:5000 ghcr.io/mlflow/mlflow:v2.10.0 mlflow server --host 0.0.0.0 --port 5000
+
+## Fixed version
+docker run -p 127.0.0.1:5000:5000 ghcr.io/mlflow/mlflow:v2.2.0 mlflow server --host 0.0.0.0 --port 5000

--- a/mlflow/CVE-2023-6977/README.md
+++ b/mlflow/CVE-2023-6977/README.md
@@ -4,8 +4,8 @@ This directory contains the deployment config for MLflow instances vulnerable an
 
 The deployed service listens on port `5000` after the docker completes its job.
 
-## Vulnerable version
+## Fixed version
 docker run -p 127.0.0.1:5000:5000 ghcr.io/mlflow/mlflow:v2.10.0 mlflow server --host 0.0.0.0 --port 5000
 
-## Fixed version
+## Vulnerable version
 docker run -p 127.0.0.1:5000:5000 ghcr.io/mlflow/mlflow:v2.2.0 mlflow server --host 0.0.0.0 --port 5000


### PR DESCRIPTION
Hi,

This is vulnerable environment for CVE-2023-6977. Related issue is https://github.com/google/tsunami-security-scanner-plugins/issues/450