### PR TITLE
New Torchserve testbed

### DIFF
--- a/torchserve/shelltorch/README.md
+++ b/torchserve/shelltorch/README.md
@@ -1,0 +1,50 @@
+# TorchServe Vulnerability Testbed
+## Overview
+This testbed provides a Docker Compose setup to test the TorchServe Management API Detection Plugin against various versions of TorchServe, demonstrating different vulnerability scenarios. It includes four TorchServe containers with varying configurations to simulate different security postures.
+
+## Prerequisites
+Before starting, ensure Docker and Docker Compose are installed on your system.
+
+## TorchServe Containers
+The testbed includes the following TorchServe containers:
+
+- **torchserve-081:** Version 0.8.1, vulnerable to the ShellTorch attack.
+- **torchserve-082:** Version 0.8.2, patched for ShellTorch but still vulnerable due to default `allowed_urls`.
+- **torchserve-safe:** Version 0.8.2 with `allowed_urls` correctly restricted, representing a secure setup.
+- **torchserve-latest:** The latest version (currently 0.12.0), with default settings, no longer vulnerable
+
+## Setup Instructions
+
+### Starting TorchServe Services
+To start all the TorchServe services in detached mode:
+
+```bash
+docker compose up -d
+```
+
+To start a specific TorchServe service, for example, `torchserve-081`:
+
+```bash
+docker compose up -d torchserve-081
+```
+
+## Using Tsunami for Testing
+
+After starting the containers using the command above, run the following command to scan the container `torchserve-081` using Tsunami. Change the container name in the `--uri-target` argument to scan the other containers.
+
+```bash
+docker compose run --rm --name=tsunami tsunami \
+    bash -c "apt-get update && apt-get install -y nmap && \
+        tsunami --uri-target=http://torchserve-081:8081 \
+        --torchserve-management-api-mode=local \
+        --torchserve-management-api-local-bind-host=tsunami \
+        --torchserve-management-api-local-bind-port=1234 \
+        --torchserve-management-api-local-accessible-url=http://tsunami:1234"
+```
+
+## Cleanup
+
+Stop and remove all the containers:
+```bash
+docker compose down
+```

--- a/torchserve/shelltorch/docker-compose.yaml
+++ b/torchserve/shelltorch/docker-compose.yaml
@@ -1,0 +1,67 @@
+# TorchServe testbed for detecting exposed management interface
+#
+# The risks of exposing TorchServe management interface to the Internet
+# were initially demonstrated in the "ShellTorch" attack
+# (https://www.oligo.security/shelltorch) that allowed arbitrary code
+# execution by chaining CVE-2023-43654 and CVE-2022-1471.
+#
+# Although TorchServe versions 0.8.2 and later are not vulnerable to
+# insecure deserialization (CVE-2022-1471), they still allow arbitrary
+# code execution via the management interface, if the `allowed_urls`
+# configuration option is not sufficiently restricted.
+#
+# This testbed builds three TorchServe containers:
+#
+#   - torchserve-081: 0.8.1, vulnerable to ShellTorch attack
+#   - torchserve-082: 0.8.2, with ShellTorch mitigations, but still vulnerable
+#   - torchserve-safe: 0.8.2, with `allowed_urls` correctly restricted
+#   - torchserve-latest: latest version, with default settings (currently 0.9.0, vulnerable)
+
+# Shared configuration for TorchServe containers
+x-torchserve-common: &torchserve-common
+  platform: linux/amd64 # TorchServe doesn't support ARM at the moment
+  networks:
+    - torchserve-network
+
+services:
+  # 0.8.1 is the last version that is vulnerable to ShellTorch attack
+  torchserve-081:
+    container_name: torchserve-081
+    <<: *torchserve-common  # Inherits common settings
+    image: pytorch/torchserve:0.8.1-cpu
+
+  # 0.8.2 with default `allowed_urls` configuration - still vulnerable
+  torchserve-082:
+    container_name: torchserve-082
+    <<: *torchserve-common
+    image: pytorch/torchserve:0.8.2-cpu
+
+  # 0.8.2 with restricted `allowed_urls` configuration - safe
+  torchserve-safe:
+    container_name: torchserve-safe
+    <<: *torchserve-common
+    image: pytorch/torchserve:0.8.2-cpu
+    entrypoint: >
+      /bin/sh -c '
+        (cat config.properties; echo "allowed_urls = http://localhost/*") > safe_config.properties;
+        torchserve --start --ts-config safe_config.properties;
+        tail -f /dev/null'
+
+  # Latest version with default `allowed_urls` configuration (atm 0.9.0, still vulnerable)
+  torchserve-latest:
+    container_name: torchserve-latest
+    <<: *torchserve-common  # Inherits common settings
+    image: pytorch/torchserve:latest-cpu  # Latest version tag
+
+  # Tsunami container
+  tsunami:
+    container_name: tsunami
+    image: ghcr.io/google/tsunami-scanner-full
+    networks:
+      - torchserve-network
+    logging:
+      driver: none
+
+networks:
+  torchserve-network:
+    driver: bridge


### PR DESCRIPTION
Original testbed here: https://github.com/google/security-testbeds/pull/10

Adapted to work with latest Tsunami version.

Testbed for TorchServe. Based on Docker Compose, includes Tsunami container and four TorchServe versions:

* torchserve-081: Version 0.8.1, vulnerable to the ShellTorch attack.
* torchserve-082: Version 0.8.2, patched for ShellTorch but still vulnerable due to default allowed_urls.
* torchserve-safe: Version 0.8.2 with allowed_urls correctly restricted, representing a secure setup.
* torchserve-latest: The latest version (currently 0.12.0), with default settings and no longer vulnerable