### PR TITLE
MLFlow CVE-2024-1483 Docker Compose Ports Change

### DIFF
--- a/mlflow/CVE-2024-1483/docker-compose.yml
+++ b/mlflow/CVE-2024-1483/docker-compose.yml
@@ -2,6 +2,10 @@ services:
   vuln:
     image: ghcr.io/mlflow/mlflow:v2.9.1
     command: ["mlflow", "server", "--host", "0.0.0.0", "--port", "5000"]
+    ports:
+      - 8081:5000
   safe:
     image: ghcr.io/mlflow/mlflow:v2.12.1
     command: ["mlflow", "server", "--host", "0.0.0.0", "--port", "5000"]
+    ports:
+      - 8082:5000


### PR DESCRIPTION
This change makes it so that the docker-compose services use different ports on the host. It makes it a little easier for testing.